### PR TITLE
fix to mathspamprotector field 

### DIFF
--- a/code/MathSpamProtectorField.php
+++ b/code/MathSpamProtectorField.php
@@ -146,4 +146,8 @@ class MathSpamProtectorField extends TextField {
 
 		return $numbers[$num];
 	}
+
+	public function Type() {
+		return 'mathspamprotector text';
+	}
 }


### PR DESCRIPTION
so that the type returns the same format as other text fields, e.g EmailField
