### PR TITLE
Create allow_numeric_answer option

### DIFF
--- a/code/MathSpamProtectorField.php
+++ b/code/MathSpamProtectorField.php
@@ -22,6 +22,13 @@ class MathSpamProtectorField extends TextField {
 	 */
 	private static $question_prefix;
 	
+	/**
+	 * @config
+	 *
+	 * @var bool $allow_numeric_answer
+	 */
+	private static $allow_numeric_answer = true;
+	
 	public function Field($properties = array()) {
 		if(Config::inst()->get('MathSpamProtectorField', 'enabled')) {
 			return parent::Field($properties);
@@ -126,7 +133,8 @@ class MathSpamProtectorField extends TextField {
 
 		$word = MathSpamProtectorField::digit_to_word($v1 + $v2);
 
-		return ($word == strtolower($answer) || ($v1 + $v2) == $answer);
+		$allow_numeric_answer = Config::inst()->get('MathSpamProtectorField', 'allow_numeric_answer');
+		return ($word == strtolower($answer) || ((($v1 + $v2) == $answer) and $allow_numeric_answer));
 	}
 
 	/**

--- a/code/MathSpamProtectorField.php
+++ b/code/MathSpamProtectorField.php
@@ -133,8 +133,7 @@ class MathSpamProtectorField extends TextField {
 
 		$word = MathSpamProtectorField::digit_to_word($v1 + $v2);
 
-		$allow_numeric_answer = Config::inst()->get('MathSpamProtectorField', 'allow_numeric_answer');
-		return ($word == strtolower($answer) || ((($v1 + $v2) == $answer) and $allow_numeric_answer));
+		return ($word == strtolower($answer) || (Config::inst()->get('MathSpamProtectorField', 'allow_numeric_answer') && (($v1 + $v2) == $answer)));
 	}
 
 	/**


### PR DESCRIPTION
This option allows you to stop accepting numeric answers as they do not always prevent spam. By default, numeric answers are accepted, so this commit does not make any unintended changes to the behaviour of this field. Closes issue #19.