### PR TITLE
Update for strict comparison with ===

### DIFF
--- a/code/MathSpamProtectorField.php
+++ b/code/MathSpamProtectorField.php
@@ -151,7 +151,7 @@ class MathSpamProtectorField extends TextField
 
         $word = MathSpamProtectorField::digit_to_word($v1 + $v2);
 
-        return ($word == strtolower($answer) || ($this->config()->get('allow_numeric_answer') && (($v1 + $v2) == $answer)));
+        return ($word == strtolower($answer) || ($this->config()->get('allow_numeric_answer') && (($v1 + $v2) === $answer)));
     }
 
     /**


### PR DESCRIPTION
problem: loose comparison with == -> Null = "0" its not type sensetive
solved: strict comparison with === -> Null = false
new session with $v1 = 0 and $v2 = 0 did lead to true answer with actually no answer given (Null -> "0")
 0 + 0 = 0 -> true
ref: https://www.php.net/manual/en/types.comparisons.php
