### PR TITLE
older php version did not coerce string -> int

### DIFF
--- a/src/MathSpamProtectorField.php
+++ b/src/MathSpamProtectorField.php
@@ -157,7 +157,7 @@ class MathSpamProtectorField extends TextField
 
         $word = MathSpamProtectorField::digit_to_word($v1 + $v2);
 
-        return ($word == strtolower($answer) || ($this->config()->get('allow_numeric_answer') && (($v1 + $v2) === $answer)));
+        return ($word == strtolower($answer) || ($this->config()->get('allow_numeric_answer') && (($v1 + $v2) === (int)$answer)));
     }
 
     /**


### PR DESCRIPTION
got some problems with older PHP versions, this change is a little bit on the lazy side but will do the work. 

https://stackoverflow.com/questions/8529656/how-do-i-convert-a-string-to-a-number-in-php
https://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting