### PR TITLE
Actually enforce strict numeric comparison for answer

### DIFF
--- a/src/MathSpamProtectorField.php
+++ b/src/MathSpamProtectorField.php
@@ -157,7 +157,7 @@ class MathSpamProtectorField extends TextField
 
         $word = MathSpamProtectorField::digit_to_word($v1 + $v2);
 
-        return ($word == strtolower($answer) || ($this->config()->get('allow_numeric_answer') && (($v1 + $v2) === $answer)));
+        return ($word == strtolower($answer) || ($this->config()->get('allow_numeric_answer') && (($v1 + $v2) === intval($answer))));
     }
 
     /**


### PR DESCRIPTION
ad36c19 identical comparison (===) broke numeric answers, as they are of string type.

```(int) $answer``` works also, I don't know which is preferred.